### PR TITLE
Change: IsGeneratableType will return false for System.Guid, DateOnly, and TimeOnly

### DIFF
--- a/src/JsonMergePatch.SourceGenerator/GeneratedTypeFilter.cs
+++ b/src/JsonMergePatch.SourceGenerator/GeneratedTypeFilter.cs
@@ -12,7 +12,17 @@ namespace LaDeak.JsonMergePatch.SourceGenerator
             bool generic = false;
             if (typeInfo is INamedTypeSymbol namedTypeInfo)
                 generic = namedTypeInfo.IsGenericType;
-            return typeInfo.SpecialType == SpecialType.None && !typeInfo.IsAnonymousType && !typeInfo.IsAbstract && !generic && !typeInfo.IsStatic && typeInfo.TypeKind != TypeKind.Enum;
+
+            // Check for System types that have SpecialType.None.
+            string typeName = typeInfo.ToDisplayString();
+            bool isNonSpecialSystemType = typeName == "System.Guid" || typeName == "System.DateOnly" || typeName == "System.TimeOnly";
+
+            return typeInfo.SpecialType == SpecialType.None
+                && !isNonSpecialSystemType
+                && !typeInfo.IsAnonymousType
+                && !typeInfo.IsAbstract
+                && !generic && !typeInfo.IsStatic
+                && typeInfo.TypeKind != TypeKind.Enum;
         }
 
 


### PR DESCRIPTION
Change: IsGeneratableType will return false for System.Guid, DateOnly, and TimeOnly. These types report as SpecialType.None, but are System value/struct types that do not require a wrapper type.

Note. DateOnly and TimeOnly were added in .NET 6.0, and therefore are not part of NetStandard2.0 (and therefore are not currently known to Microsoft.CodeAnalysis).

This addresses #66 