### PR TITLE
Builder pattern

### DIFF
--- a/sample/AspNetCoreMinimal.Entities/Entities.cs
+++ b/sample/AspNetCoreMinimal.Entities/Entities.cs
@@ -31,5 +31,5 @@ public class Tag
 {
     public int Id { get; set; }
 
-    public string? Name { get; set; }
+    public string? Value { get; set; }
 }

--- a/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/ApplyPatchBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/ApplyPatchBuilder.cs
@@ -1,0 +1,28 @@
+﻿namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders
+{
+    public abstract class ApplyPatchBuilder
+    {
+        /// <summary>
+        /// Generates logic to instantiate object for init property.
+        /// </summary>
+        /// <param name="state">The state representing the ApplyPatch method.</param>
+        /// <param name="i">The index of the property in the 'Properties' collection.</param>
+        /// <returns>Returns the new state.</returns>
+        public abstract BuilderState BuildInitOnly(BuilderState state, int i);
+
+        /// <summary>
+        /// Generates logic to instantiate object for non-init property.
+        /// </summary>
+        /// <param name="state">The state representing the ApplyPatch method.</param>
+        /// <param name="i">The index of the property in the 'Properties' collection.</param>
+        /// <returns>Returns the new state.</returns>
+        public abstract BuilderState BuildInstantiation(BuilderState state, int i);
+
+        /// <summary>
+        /// Generates merging logic for complex state (Dictionary, List).
+        /// </summary>
+        /// <param name="state">The state representing the ApplyPatch method.</param>
+        /// <returns>Returns the new state.</returns>
+        public abstract BuilderState BuildPatch(BuilderState state);
+    }
+}

--- a/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/ApplyPatchBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/ApplyPatchBuilder.cs
@@ -1,28 +1,27 @@
-﻿namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders
+﻿namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders;
+
+public abstract class ApplyPatchBuilder
 {
-    public abstract class ApplyPatchBuilder
-    {
-        /// <summary>
-        /// Generates logic to instantiate object for init property.
-        /// </summary>
-        /// <param name="state">The state representing the ApplyPatch method.</param>
-        /// <param name="i">The index of the property in the 'Properties' collection.</param>
-        /// <returns>Returns the new state.</returns>
-        public abstract BuilderState BuildInitOnly(BuilderState state, int i);
+    /// <summary>
+    /// Generates logic to instantiate object for init property.
+    /// </summary>
+    /// <param name="state">The state representing the ApplyPatch method.</param>
+    /// <param name="i">The index of the property in the 'Properties' collection.</param>
+    /// <returns>Returns the new state.</returns>
+    public abstract BuilderState BuildInitOnly(BuilderState state, int i);
 
-        /// <summary>
-        /// Generates logic to instantiate object for non-init property.
-        /// </summary>
-        /// <param name="state">The state representing the ApplyPatch method.</param>
-        /// <param name="i">The index of the property in the 'Properties' collection.</param>
-        /// <returns>Returns the new state.</returns>
-        public abstract BuilderState BuildInstantiation(BuilderState state, int i);
+    /// <summary>
+    /// Generates logic to instantiate object for non-init property.
+    /// </summary>
+    /// <param name="state">The state representing the ApplyPatch method.</param>
+    /// <param name="i">The index of the property in the 'Properties' collection.</param>
+    /// <returns>Returns the new state.</returns>
+    public abstract BuilderState BuildInstantiation(BuilderState state, int i);
 
-        /// <summary>
-        /// Generates merging logic for complex state (Dictionary, List).
-        /// </summary>
-        /// <param name="state">The state representing the ApplyPatch method.</param>
-        /// <returns>Returns the new state.</returns>
-        public abstract BuilderState BuildPatch(BuilderState state);
-    }
+    /// <summary>
+    /// Generates merging logic for complex state (Dictionary, List).
+    /// </summary>
+    /// <param name="state">The state representing the ApplyPatch method.</param>
+    /// <returns>Returns the new state.</returns>
+    public abstract BuilderState BuildPatch(BuilderState state);
 }

--- a/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/GeneratableListBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/GeneratableListBuilder.cs
@@ -2,57 +2,59 @@
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
-namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders
+namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders;
+
+/// <summary>
+/// Builds ApplyPatch method for <see cref="System.Collections.Generic.List{T}"/> with user types where a Wrapper DTO is generated for the generic type argument.
+/// </summary>
+public class GeneratableListBuilder : ApplyPatchBuilder
 {
-    public class GeneratableListBuilder : ApplyPatchBuilder
+    private readonly ITypeSymbol _firstGenericType;
+    private readonly IPropertySymbol _property;
+
+    public GeneratableListBuilder(INamedTypeSymbol namedType, IPropertySymbol property)
     {
-        private readonly ITypeSymbol _firstGenericType;
-        private readonly IPropertySymbol _property;
-
-        public GeneratableListBuilder(INamedTypeSymbol namedType, IPropertySymbol property)
+        if (!namedType.Name.Contains("List")
+           || namedType.ContainingNamespace.ToDisplayString() != "System.Collections.Generic"
+           || !GeneratedTypeFilter.IsGeneratableType(namedType.TypeArguments.First()))
         {
-            if (!namedType.Name.Contains("List")
-               || namedType.ContainingNamespace.ToDisplayString() != "System.Collections.Generic"
-               || !GeneratedTypeFilter.IsGeneratableType(namedType.TypeArguments.First()))
-            {
-                throw new ArgumentException("Input argument type is not a generic list with generatable type.");
-            }
-            _firstGenericType = namedType.TypeArguments.First();
-            _property = property;
+            throw new ArgumentException("Input argument type is not a generic list with generatable type.");
         }
-
-        public override BuilderState BuildInitOnly(BuilderState state, int i)
-        {
-            state.AppendLine($"{_property.Name} = Properties[{i}] && input.{_property.Name} == null ? new() : input.{_property.Name},");
-            return state;
-        }
-
-        public override BuilderState BuildInstantiation(BuilderState state, int i)
-        {
-            state.AppendLine($"if (Properties[{i}])");
-            state.IncrementIdentation().AppendLine($"input.{_property.Name} = new();");
-            return state;
-        }
-
-        public override BuilderState BuildPatch(BuilderState state)
-        {
-            if (_firstGenericType != null && GeneratedTypeFilter.IsGeneratableType(_firstGenericType))
-                PopulateGeneratableListProperties(state, _property);
-            return state;
-        }
-
-        private void PopulateGeneratableListProperties(BuilderState state, IPropertySymbol property)
-        {
-            var propertyName = property.Name;
-            state.AppendLine($"if({propertyName} != null)");
-            state.AppendLine("{");
-            var ifBody = state.IncrementIdentation();
-            ifBody.AppendLine($"foreach(var item in {propertyName})");
-            ifBody.AppendLine("{");
-            ifBody.IncrementIdentation().AppendLine($"input.{propertyName}.Add(item?.ApplyPatch(null));");
-            ifBody.AppendLine("}");
-            state.AppendLine("}");
-        }
+        _firstGenericType = namedType.TypeArguments.First();
+        _property = property;
     }
 
+    public override BuilderState BuildInitOnly(BuilderState state, int i)
+    {
+        state.AppendLine($"{_property.Name} = Properties[{i}] && input.{_property.Name} == null ? new() : input.{_property.Name},");
+        return state;
+    }
+
+    public override BuilderState BuildInstantiation(BuilderState state, int i)
+    {
+        state.AppendLine($"if (Properties[{i}])");
+        state.IncrementIdentation().AppendLine($"input.{_property.Name} = new();");
+        return state;
+    }
+
+    public override BuilderState BuildPatch(BuilderState state)
+    {
+        if (_firstGenericType != null && GeneratedTypeFilter.IsGeneratableType(_firstGenericType))
+            PopulateGeneratableListProperties(state, _property);
+        return state;
+    }
+
+    private void PopulateGeneratableListProperties(BuilderState state, IPropertySymbol property)
+    {
+        var propertyName = property.Name;
+        state.AppendLine($"if({propertyName} != null)");
+        state.AppendLine("{");
+        var ifBody = state.IncrementIdentation();
+        ifBody.AppendLine($"foreach(var item in {propertyName})");
+        ifBody.AppendLine("{");
+        ifBody.IncrementIdentation().AppendLine($"input.{propertyName}.Add(item?.ApplyPatch(null));");
+        ifBody.AppendLine("}");
+        state.AppendLine("}");
+    }
 }
+

--- a/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/GeneratableListBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/GeneratableListBuilder.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders
+{
+    public class GeneratableListBuilder : ApplyPatchBuilder
+    {
+        private readonly ITypeSymbol _firstGenericType;
+        private readonly IPropertySymbol _property;
+
+        public GeneratableListBuilder(INamedTypeSymbol namedType, IPropertySymbol property)
+        {
+            if (!namedType.Name.Contains("List")
+               || namedType.ContainingNamespace.ToDisplayString() != "System.Collections.Generic"
+               || !GeneratedTypeFilter.IsGeneratableType(namedType.TypeArguments.First()))
+            {
+                throw new ArgumentException("Input argument type is not a generic list with generatable type.");
+            }
+            _firstGenericType = namedType.TypeArguments.First();
+            _property = property;
+        }
+
+        public override BuilderState BuildInitOnly(BuilderState state, int i)
+        {
+            state.AppendLine($"{_property.Name} = Properties[{i}] && input.{_property.Name} == null ? new() : input.{_property.Name},");
+            return state;
+        }
+
+        public override BuilderState BuildInstantiation(BuilderState state, int i)
+        {
+            state.AppendLine($"if (Properties[{i}])");
+            state.IncrementIdentation().AppendLine($"input.{_property.Name} = new();");
+            return state;
+        }
+
+        public override BuilderState BuildPatch(BuilderState state)
+        {
+            if (_firstGenericType != null && GeneratedTypeFilter.IsGeneratableType(_firstGenericType))
+                PopulateGeneratableListProperties(state, _property);
+            return state;
+        }
+
+        private void PopulateGeneratableListProperties(BuilderState state, IPropertySymbol property)
+        {
+            var propertyName = property.Name;
+            state.AppendLine($"if({propertyName} != null)");
+            state.AppendLine("{");
+            var ifBody = state.IncrementIdentation();
+            ifBody.AppendLine($"foreach(var item in {propertyName})");
+            ifBody.AppendLine("{");
+            ifBody.IncrementIdentation().AppendLine($"input.{propertyName}.Add(item?.ApplyPatch(null));");
+            ifBody.AppendLine("}");
+            state.AppendLine("}");
+        }
+    }
+
+}

--- a/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/NonGeneratableDictionaryPatchBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/NonGeneratableDictionaryPatchBuilder.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+
+namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders
+{
+    public class NonGeneratableDictionaryPatchBuilder : ApplyPatchBuilder
+    {
+        private readonly INamedTypeSymbol _namedType;
+        private readonly IPropertySymbol _property;
+        private readonly bool _isConvertedToNullableType;
+
+        public NonGeneratableDictionaryPatchBuilder(INamedTypeSymbol namedType, IPropertySymbol property, bool isConvertedToNullableType)
+        {
+            if (!namedType.Name.Contains("Dictionary") || namedType.ContainingNamespace.ToDisplayString() != "System.Collections.Generic")
+                throw new ArgumentException($"Input argument type is not a valid for {nameof(NonGeneratableDictionaryPatchBuilder)}");
+            _namedType = namedType;
+            _property = property;
+            _isConvertedToNullableType = isConvertedToNullableType;
+        }
+
+        public override BuilderState BuildInitOnly(BuilderState state, int i)
+        {
+            state.AppendLine($"{_property.Name} = Properties[{i}] && input.{_property.Name} == null ? new() : input.Values,");
+            return state;
+        }
+
+        public override BuilderState BuildInstantiation(BuilderState state, int i)
+        {
+            state.AppendLine($"if (Properties[{i}])");
+            state.IncrementIdentation().AppendLine($"input.{_property.Name} ??= new();");
+            return state;
+        }
+
+        public override BuilderState BuildPatch(BuilderState state)
+        {
+            if (!GeneratedTypeFilter.IsGeneratableType(_property.Type))
+                PopulateDictionary(state, _property);
+            return state;
+        }
+
+        private void PopulateDictionary(BuilderState state, IPropertySymbol property)
+        {
+            var propertyName = property.Name;
+            state.AppendLine($"if({propertyName} != null)");
+            state.AppendLine("{");
+            var ifBody = state.IncrementIdentation();
+            ifBody.AppendLine($"foreach(var item in {propertyName})");
+            ifBody.AppendLine("{");
+            var foreachBody = ifBody.IncrementIdentation();
+            foreachBody.AppendLine("if(item.Value is null)");
+            foreachBody.IncrementIdentation().AppendLine($"input.{propertyName}.Remove(item.Key);");
+            foreachBody.AppendLine("else");
+            if (_isConvertedToNullableType)
+                foreachBody.IncrementIdentation().AppendLine($"input.{propertyName}[item.Key] = item.Value.Value;");
+            else
+                foreachBody.IncrementIdentation().AppendLine($"input.{propertyName}[item.Key] = item.Value;");
+            ifBody.AppendLine("}");
+            state.AppendLine("}");
+        }
+    }
+}

--- a/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/NonGeneratableDictionaryPatchBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/NonGeneratableDictionaryPatchBuilder.cs
@@ -1,61 +1,63 @@
 ﻿using System;
 using Microsoft.CodeAnalysis;
 
-namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders
+namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders;
+
+/// <summary>
+/// Builds ApplyPatch method for Dictionaries with generic type parameters where no wrapper is generated, or the type is nullable.
+/// </summary>
+public class NonGeneratableDictionaryPatchBuilder : ApplyPatchBuilder
 {
-    public class NonGeneratableDictionaryPatchBuilder : ApplyPatchBuilder
+    private readonly INamedTypeSymbol _namedType;
+    private readonly IPropertySymbol _property;
+    private readonly bool _isConvertedToNullableType;
+
+    public NonGeneratableDictionaryPatchBuilder(INamedTypeSymbol namedType, IPropertySymbol property, bool isConvertedToNullableType)
     {
-        private readonly INamedTypeSymbol _namedType;
-        private readonly IPropertySymbol _property;
-        private readonly bool _isConvertedToNullableType;
+        if (!namedType.Name.Contains("Dictionary") || namedType.ContainingNamespace.ToDisplayString() != "System.Collections.Generic")
+            throw new ArgumentException($"Input argument type is not a valid for {nameof(NonGeneratableDictionaryPatchBuilder)}");
+        _namedType = namedType;
+        _property = property;
+        _isConvertedToNullableType = isConvertedToNullableType;
+    }
 
-        public NonGeneratableDictionaryPatchBuilder(INamedTypeSymbol namedType, IPropertySymbol property, bool isConvertedToNullableType)
-        {
-            if (!namedType.Name.Contains("Dictionary") || namedType.ContainingNamespace.ToDisplayString() != "System.Collections.Generic")
-                throw new ArgumentException($"Input argument type is not a valid for {nameof(NonGeneratableDictionaryPatchBuilder)}");
-            _namedType = namedType;
-            _property = property;
-            _isConvertedToNullableType = isConvertedToNullableType;
-        }
+    public override BuilderState BuildInitOnly(BuilderState state, int i)
+    {
+        state.AppendLine($"{_property.Name} = Properties[{i}] && input.{_property.Name} == null ? new() : input.Values,");
+        return state;
+    }
 
-        public override BuilderState BuildInitOnly(BuilderState state, int i)
-        {
-            state.AppendLine($"{_property.Name} = Properties[{i}] && input.{_property.Name} == null ? new() : input.Values,");
-            return state;
-        }
+    public override BuilderState BuildInstantiation(BuilderState state, int i)
+    {
+        state.AppendLine($"if (Properties[{i}])");
+        state.IncrementIdentation().AppendLine($"input.{_property.Name} ??= new();");
+        return state;
+    }
 
-        public override BuilderState BuildInstantiation(BuilderState state, int i)
-        {
-            state.AppendLine($"if (Properties[{i}])");
-            state.IncrementIdentation().AppendLine($"input.{_property.Name} ??= new();");
-            return state;
-        }
+    public override BuilderState BuildPatch(BuilderState state)
+    {
+        if (!GeneratedTypeFilter.IsGeneratableType(_property.Type))
+            PopulateDictionary(state, _property);
+        return state;
+    }
 
-        public override BuilderState BuildPatch(BuilderState state)
-        {
-            if (!GeneratedTypeFilter.IsGeneratableType(_property.Type))
-                PopulateDictionary(state, _property);
-            return state;
-        }
-
-        private void PopulateDictionary(BuilderState state, IPropertySymbol property)
-        {
-            var propertyName = property.Name;
-            state.AppendLine($"if({propertyName} != null)");
-            state.AppendLine("{");
-            var ifBody = state.IncrementIdentation();
-            ifBody.AppendLine($"foreach(var item in {propertyName})");
-            ifBody.AppendLine("{");
-            var foreachBody = ifBody.IncrementIdentation();
-            foreachBody.AppendLine("if(item.Value is null)");
-            foreachBody.IncrementIdentation().AppendLine($"input.{propertyName}.Remove(item.Key);");
-            foreachBody.AppendLine("else");
-            if (_isConvertedToNullableType)
-                foreachBody.IncrementIdentation().AppendLine($"input.{propertyName}[item.Key] = item.Value.Value;");
-            else
-                foreachBody.IncrementIdentation().AppendLine($"input.{propertyName}[item.Key] = item.Value;");
-            ifBody.AppendLine("}");
-            state.AppendLine("}");
-        }
+    private void PopulateDictionary(BuilderState state, IPropertySymbol property)
+    {
+        var propertyName = property.Name;
+        state.AppendLine($"if({propertyName} != null)");
+        state.AppendLine("{");
+        var ifBody = state.IncrementIdentation();
+        ifBody.AppendLine($"foreach(var item in {propertyName})");
+        ifBody.AppendLine("{");
+        var foreachBody = ifBody.IncrementIdentation();
+        foreachBody.AppendLine("if(item.Value is null)");
+        foreachBody.IncrementIdentation().AppendLine($"input.{propertyName}.Remove(item.Key);");
+        foreachBody.AppendLine("else");
+        if (_isConvertedToNullableType)
+            foreachBody.IncrementIdentation().AppendLine($"input.{propertyName}[item.Key] = item.Value.Value;");
+        else
+            foreachBody.IncrementIdentation().AppendLine($"input.{propertyName}[item.Key] = item.Value;");
+        ifBody.AppendLine("}");
+        state.AppendLine("}");
     }
 }

--- a/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/SimpleGeneratableBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/SimpleGeneratableBuilder.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+
+namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders
+{
+    /// <summary>
+    /// Builds ApplyPatch method for user types where a Wrapper DTO is generated.
+    /// </summary>
+    public class SimpleGeneratableBuilder : ApplyPatchBuilder
+    {
+        private readonly IPropertySymbol _propertySymbol;
+
+        public SimpleGeneratableBuilder(IPropertySymbol propertySymbol)
+        {
+            if (!GeneratedTypeFilter.IsGeneratableType(propertySymbol.Type))
+                throw new ArgumentException("The given property is not simple generatable");
+            _propertySymbol = propertySymbol;
+        }
+
+        public override BuilderState BuildInitOnly(BuilderState state, int i)
+        {
+            state.AppendLine($"{_propertySymbol.Name} = Properties[{i}] ? this.{_propertySymbol.Name}?.ApplyPatch(input.{_propertySymbol.Name}) : input.{_propertySymbol.Name},");
+            return state;
+        }
+
+        public override BuilderState BuildInstantiation(BuilderState state, int i)
+        {
+            state.AppendLine($"if (Properties[{i}])");
+            state.IncrementIdentation().AppendLine($"input.{_propertySymbol.Name} = {_propertySymbol.Name}?.ApplyPatch(input.{_propertySymbol.Name});");
+            return state;
+        }
+
+        public override BuilderState BuildPatch(BuilderState state)
+        {
+            return state;
+        }
+    }
+
+}

--- a/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/SimpleGeneratableBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/SimpleGeneratableBuilder.cs
@@ -1,39 +1,38 @@
 ﻿using System;
 using Microsoft.CodeAnalysis;
 
-namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders
+namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders;
+
+/// <summary>
+/// Builds ApplyPatch method for user types where a Wrapper DTO is generated.
+/// </summary>
+public class SimpleGeneratableBuilder : ApplyPatchBuilder
 {
-    /// <summary>
-    /// Builds ApplyPatch method for user types where a Wrapper DTO is generated.
-    /// </summary>
-    public class SimpleGeneratableBuilder : ApplyPatchBuilder
+    private readonly IPropertySymbol _propertySymbol;
+
+    public SimpleGeneratableBuilder(IPropertySymbol propertySymbol)
     {
-        private readonly IPropertySymbol _propertySymbol;
-
-        public SimpleGeneratableBuilder(IPropertySymbol propertySymbol)
-        {
-            if (!GeneratedTypeFilter.IsGeneratableType(propertySymbol.Type))
-                throw new ArgumentException("The given property is not simple generatable");
-            _propertySymbol = propertySymbol;
-        }
-
-        public override BuilderState BuildInitOnly(BuilderState state, int i)
-        {
-            state.AppendLine($"{_propertySymbol.Name} = Properties[{i}] ? this.{_propertySymbol.Name}?.ApplyPatch(input.{_propertySymbol.Name}) : input.{_propertySymbol.Name},");
-            return state;
-        }
-
-        public override BuilderState BuildInstantiation(BuilderState state, int i)
-        {
-            state.AppendLine($"if (Properties[{i}])");
-            state.IncrementIdentation().AppendLine($"input.{_propertySymbol.Name} = {_propertySymbol.Name}?.ApplyPatch(input.{_propertySymbol.Name});");
-            return state;
-        }
-
-        public override BuilderState BuildPatch(BuilderState state)
-        {
-            return state;
-        }
+        if (!GeneratedTypeFilter.IsGeneratableType(propertySymbol.Type))
+            throw new ArgumentException("The given property is not simple generatable");
+        _propertySymbol = propertySymbol;
     }
 
+    public override BuilderState BuildInitOnly(BuilderState state, int i)
+    {
+        state.AppendLine($"{_propertySymbol.Name} = Properties[{i}] ? this.{_propertySymbol.Name}?.ApplyPatch(input.{_propertySymbol.Name}) : input.{_propertySymbol.Name},");
+        return state;
+    }
+
+    public override BuilderState BuildInstantiation(BuilderState state, int i)
+    {
+        state.AppendLine($"if (Properties[{i}])");
+        state.IncrementIdentation().AppendLine($"input.{_propertySymbol.Name} = {_propertySymbol.Name}?.ApplyPatch(input.{_propertySymbol.Name});");
+        return state;
+    }
+
+    public override BuilderState BuildPatch(BuilderState state)
+    {
+        return state;
+    }
 }
+

--- a/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/SimpleNonGeneratableBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/SimpleNonGeneratableBuilder.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+
+namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders
+{
+    /// <summary>
+    /// Builds ApplyPatch method for user types where no wrapper is generated, or the type is nullable.
+    /// </summary>
+    public class SimpleNonGeneratableBuilder : ApplyPatchBuilder
+    {
+        private readonly IPropertySymbol _propertySymbol;
+        private readonly bool _isConvertedToNullable;
+
+        public SimpleNonGeneratableBuilder(IPropertySymbol propertySymbol, bool isConvertedToNullable)
+        {
+            if (GeneratedTypeFilter.IsGeneratableType(propertySymbol.Type))
+                throw new ArgumentException("The given property is not simple generatable");
+            _propertySymbol = propertySymbol;
+            _isConvertedToNullable = isConvertedToNullable;
+        }
+
+        public override BuilderState BuildInitOnly(BuilderState state, int i)
+        {
+            if (_isConvertedToNullable)
+                state.AppendLine($"{_propertySymbol.Name} = Properties[{i}] ? ({_propertySymbol.Name}.HasValue ? this.{_propertySymbol.Name}.Value : default) : input.{_propertySymbol.Name},");
+            else
+                state.AppendLine($"{_propertySymbol.Name} = Properties[{i}] ? this.{_propertySymbol.Name} : input.{_propertySymbol.Name},");
+            return state;
+        }
+
+        public override BuilderState BuildInstantiation(BuilderState state, int i)
+        {
+            state.AppendLine($"if (Properties[{i}])");
+            if (_isConvertedToNullable)
+                state.IncrementIdentation().AppendLine($"input.{_propertySymbol.Name} = {_propertySymbol.Name}.HasValue ? {_propertySymbol.Name}.Value : default;");
+            else
+                state.IncrementIdentation().AppendLine($"input.{_propertySymbol.Name} = {_propertySymbol.Name};");
+            return state;
+        }
+
+        public override BuilderState BuildPatch(BuilderState state)
+        {
+            return state;
+        }
+    }
+
+}

--- a/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/SimpleNonGeneratableBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/ApplyPatchBuilders/SimpleNonGeneratableBuilder.cs
@@ -1,47 +1,46 @@
 ﻿using System;
 using Microsoft.CodeAnalysis;
 
-namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders
+namespace LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders;
+
+/// <summary>
+/// Builds ApplyPatch method for types where no wrapper is generated, or the type is nullable.
+/// </summary>
+public class SimpleNonGeneratableBuilder : ApplyPatchBuilder
 {
-    /// <summary>
-    /// Builds ApplyPatch method for user types where no wrapper is generated, or the type is nullable.
-    /// </summary>
-    public class SimpleNonGeneratableBuilder : ApplyPatchBuilder
+    private readonly IPropertySymbol _propertySymbol;
+    private readonly bool _isConvertedToNullable;
+
+    public SimpleNonGeneratableBuilder(IPropertySymbol propertySymbol, bool isConvertedToNullable)
     {
-        private readonly IPropertySymbol _propertySymbol;
-        private readonly bool _isConvertedToNullable;
-
-        public SimpleNonGeneratableBuilder(IPropertySymbol propertySymbol, bool isConvertedToNullable)
-        {
-            if (GeneratedTypeFilter.IsGeneratableType(propertySymbol.Type))
-                throw new ArgumentException("The given property is not simple generatable");
-            _propertySymbol = propertySymbol;
-            _isConvertedToNullable = isConvertedToNullable;
-        }
-
-        public override BuilderState BuildInitOnly(BuilderState state, int i)
-        {
-            if (_isConvertedToNullable)
-                state.AppendLine($"{_propertySymbol.Name} = Properties[{i}] ? ({_propertySymbol.Name}.HasValue ? this.{_propertySymbol.Name}.Value : default) : input.{_propertySymbol.Name},");
-            else
-                state.AppendLine($"{_propertySymbol.Name} = Properties[{i}] ? this.{_propertySymbol.Name} : input.{_propertySymbol.Name},");
-            return state;
-        }
-
-        public override BuilderState BuildInstantiation(BuilderState state, int i)
-        {
-            state.AppendLine($"if (Properties[{i}])");
-            if (_isConvertedToNullable)
-                state.IncrementIdentation().AppendLine($"input.{_propertySymbol.Name} = {_propertySymbol.Name}.HasValue ? {_propertySymbol.Name}.Value : default;");
-            else
-                state.IncrementIdentation().AppendLine($"input.{_propertySymbol.Name} = {_propertySymbol.Name};");
-            return state;
-        }
-
-        public override BuilderState BuildPatch(BuilderState state)
-        {
-            return state;
-        }
+        if (GeneratedTypeFilter.IsGeneratableType(propertySymbol.Type))
+            throw new ArgumentException("The given property is not simple generatable");
+        _propertySymbol = propertySymbol;
+        _isConvertedToNullable = isConvertedToNullable;
     }
 
+    public override BuilderState BuildInitOnly(BuilderState state, int i)
+    {
+        if (_isConvertedToNullable)
+            state.AppendLine($"{_propertySymbol.Name} = Properties[{i}] ? ({_propertySymbol.Name}.HasValue ? this.{_propertySymbol.Name}.Value : default) : input.{_propertySymbol.Name},");
+        else
+            state.AppendLine($"{_propertySymbol.Name} = Properties[{i}] ? this.{_propertySymbol.Name} : input.{_propertySymbol.Name},");
+        return state;
+    }
+
+    public override BuilderState BuildInstantiation(BuilderState state, int i)
+    {
+        state.AppendLine($"if (Properties[{i}])");
+        if (_isConvertedToNullable)
+            state.IncrementIdentation().AppendLine($"input.{_propertySymbol.Name} = {_propertySymbol.Name}.HasValue ? {_propertySymbol.Name}.Value : default;");
+        else
+            state.IncrementIdentation().AppendLine($"input.{_propertySymbol.Name} = {_propertySymbol.Name};");
+        return state;
+    }
+
+    public override BuilderState BuildPatch(BuilderState state)
+    {
+        return state;
+    }
 }
+

--- a/src/JsonMergePatch.SourceGenerator/TypeBuilder.cs
+++ b/src/JsonMergePatch.SourceGenerator/TypeBuilder.cs
@@ -4,271 +4,270 @@ using System.Linq;
 using LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders;
 using Microsoft.CodeAnalysis;
 
-namespace LaDeak.JsonMergePatch.SourceGenerator
+namespace LaDeak.JsonMergePatch.SourceGenerator;
+
+public class TypeBuilder : ITypeBuilder
 {
-    public class TypeBuilder : ITypeBuilder
+    public GeneratedWrapper BuildWrapperType(ITypeSymbol typeInfo, string sourceTypeName)
     {
-        public GeneratedWrapper BuildWrapperType(ITypeSymbol typeInfo, string sourceTypeName)
+        var name = NameBuilder.GetName(typeInfo);
+        var state = InitializeState(typeInfo, name, sourceTypeName);
+        BuildFile(state);
+        return new GeneratedWrapper()
         {
-            var name = NameBuilder.GetName(typeInfo);
-            var state = InitializeState(typeInfo, name, sourceTypeName);
-            BuildFile(state);
-            return new GeneratedWrapper()
-            {
-                FileName = $"LaDeakJsonMergePatch{NameBuilder.GetNamespaceExtension(typeInfo)}{name}",
-                SourceCode = state.Builder.ToString(),
-                SourceTypeFullName = sourceTypeName,
-                TargetTypeFullName = NameBuilder.GetFullTypeName(typeInfo),
-                ToProcessTypes = state.ToProcessTypeSymbols
-            };
+            FileName = $"LaDeakJsonMergePatch{NameBuilder.GetNamespaceExtension(typeInfo)}{name}",
+            SourceCode = state.Builder.ToString(),
+            SourceTypeFullName = sourceTypeName,
+            TargetTypeFullName = NameBuilder.GetFullTypeName(typeInfo),
+            ToProcessTypes = state.ToProcessTypeSymbols
+        };
+    }
+
+    private void BuildFile(BuilderState state) => BuildNamespace(state, BuildClass);
+
+    private void BuildClass(BuilderState state) => BuildClassDeclaration(state, s => BuildClassBody(s));
+
+    private BuilderState InitializeState(ITypeSymbol typeInfo, string name, string sourceTypeName)
+    {
+        var typeInformation = new TypeInformation() { Name = name, SourceTypeName = sourceTypeName, TypeSymbol = typeInfo };
+
+        var currentType = typeInfo;
+        while (currentType != null && currentType.Name != "Object")
+        {
+            typeInformation.Properties.AddRange(currentType.GetMembers().OfType<IPropertySymbol>()
+                .Where(x => !x.IsReadOnly && !x.IsWriteOnly && !x.IsIndexer && !x.IsStatic && !x.IsAbstract && !x.IsVirtual).Select(x => new PropertyInformation() { Property = x, IsConvertedToNullableType = false }));
+            currentType = currentType.BaseType;
         }
 
-        private void BuildFile(BuilderState state) => BuildNamespace(state, BuildClass);
+        return new BuilderState(typeInformation);
+    }
 
-        private void BuildClass(BuilderState state) => BuildClassDeclaration(state, s => BuildClassBody(s));
+    private void BuildNamespace(BuilderState state, Action<BuilderState>? addBody = null)
+    {
+        state.AppendLine($"#nullable enable");
+        state.AppendLine($"namespace {NameBuilder.GetNamespace(state.TypeInfo.TypeSymbol)}");
+        state.AppendLine("{");
+        addBody?.Invoke(state.IncrementIdentation());
+        state.AppendLine("}");
+        state.AppendLine($"#nullable disable");
+    }
 
-        private BuilderState InitializeState(ITypeSymbol typeInfo, string name, string sourceTypeName)
+    private void BuildClassDeclaration(BuilderState state, Action<BuilderState>? addBody = null)
+    {
+        BuildAttributes(state, state.TypeInfo.TypeSymbol.GetAttributes());
+        state.AppendLine($"public class {state.TypeInfo.Name} : LaDeak.JsonMergePatch.Abstractions.Patch<{state.TypeInfo.SourceTypeName}>");
+        state.AppendLine("{");
+        addBody?.Invoke(state.IncrementIdentation());
+        state.AppendLine("}");
+    }
+
+    private void BuildConstructor(BuilderState state, Action<BuilderState>? addBody = null)
+    {
+        state.AppendLine($"public {state.TypeInfo.Name}()");
+        state.AppendLine("{");
+        var innerState = state.IncrementIdentation();
+        innerState.AppendLine($"Properties = new bool[{state.TypeInfo.Properties.Count}];");
+        addBody?.Invoke(innerState);
+        state.AppendLine("}");
+    }
+
+    private void BuildPropery(BuilderState state, PropertyInformation propertyInfo, int propertyId)
+    {
+        state.ToProcessTypeSymbols.Add(propertyInfo.Property.Type);
+        string fieldName = Casing.PrefixUnderscoreCamelCase(propertyInfo.Property.Name);
+        string propertyTypeName = GetPropertyTypeName(propertyInfo);
+        state.AppendLine($"private {propertyTypeName} {fieldName};");
+        BuildAttributes(state, propertyInfo.Property.GetAttributes());
+        state.AppendLine($"public {propertyTypeName} {propertyInfo.Property.Name}");
+        state.AppendLine("{");
+        var getterSetter = state.IncrementIdentation();
+        getterSetter.AppendLine($"get {{ return {fieldName}; }}");
+        getterSetter.AppendLine("set");
+        getterSetter.AppendLine("{");
+        var setterBody = getterSetter.IncrementIdentation();
+        setterBody.AppendLine($"Properties[{propertyId}] = true;");
+        setterBody.AppendLine($"{fieldName} = value;");
+        getterSetter.AppendLine("}");
+        state.AppendLine("}");
+    }
+
+    private string GetPropertyTypeName(PropertyInformation propertyInfo)
+    {
+        var propertyTypeSymbol = propertyInfo.Property.Type;
+        if (propertyTypeSymbol is INamedTypeSymbol namedType && namedType.IsGenericType)
+            return CreateGenericTypeWithParameters(propertyInfo);
+
+        return ConvertToNullableIfRequired(propertyInfo, propertyTypeSymbol);
+    }
+
+    private string CreateGenericTypeWithParameters(PropertyInformation propertyInfo)
+    {
+        if (propertyInfo?.Property?.Type is not INamedTypeSymbol namedType || !namedType.IsGenericType)
+            throw new InvalidOperationException("Parameter is not generic type parameter.");
+
+        propertyInfo.Builder = new SimpleNonGeneratableBuilder(propertyInfo.Property, false);
+        var firstUnderlyingType = GetPropertyTypeName(namedType.TypeArguments.First()).TypeName;
+        var withoutUnderlyingType = namedType.ToDisplayString(new SymbolDisplayFormat(SymbolDisplayGlobalNamespaceStyle.Omitted, SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces, SymbolDisplayGenericsOptions.None, SymbolDisplayMemberOptions.None, SymbolDisplayDelegateStyle.NameOnly, SymbolDisplayExtensionMethodStyle.Default, SymbolDisplayParameterOptions.IncludeType, SymbolDisplayPropertyStyle.NameOnly, SymbolDisplayLocalOptions.IncludeType, SymbolDisplayKindOptions.None, SymbolDisplayMiscellaneousOptions.ExpandNullable));
+
+        var genericResult = $"{withoutUnderlyingType}<{firstUnderlyingType}";
+        foreach (var underlyingType in namedType.TypeArguments.Skip(1).OfType<INamedTypeSymbol>())
         {
-            var typeInformation = new TypeInformation() { Name = name, SourceTypeName = sourceTypeName, TypeSymbol = typeInfo };
+            string genericTypeParam = ConvertToNullableIfRequired(propertyInfo, underlyingType);
+            genericResult += $", {genericTypeParam}";
+        }
+        genericResult += ">";
+        if (namedType.SpecialType != SpecialType.System_Nullable_T && namedType.NullableAnnotation != NullableAnnotation.Annotated)
+        {
+            genericResult += "?";
+        }
+        if (namedType.Name.Contains("Dictionary") && namedType.ContainingNamespace.ToDisplayString() == "System.Collections.Generic")
+            propertyInfo.Builder = new NonGeneratableDictionaryPatchBuilder(namedType, propertyInfo.Property, propertyInfo.IsConvertedToNullableType);
 
-            var currentType = typeInfo;
-            while (currentType != null && currentType.Name != "Object")
-            {
-                typeInformation.Properties.AddRange(currentType.GetMembers().OfType<IPropertySymbol>()
-                    .Where(x => !x.IsReadOnly && !x.IsWriteOnly && !x.IsIndexer && !x.IsStatic && !x.IsAbstract && !x.IsVirtual).Select(x => new PropertyInformation() { Property = x, IsConvertedToNullableType = false }));
-                currentType = currentType.BaseType;
-            }
+        if (namedType.Name.Contains("List")
+            && namedType.ContainingNamespace.ToDisplayString() == "System.Collections.Generic"
+            && !IsInitOnlyProperty(propertyInfo.Property)
+            && GeneratedTypeFilter.IsGeneratableType(namedType.TypeArguments.First()))
+            propertyInfo.Builder = new GeneratableListBuilder(namedType, propertyInfo.Property);
 
-            return new BuilderState(typeInformation);
+        return genericResult;
+    }
+
+    private string ConvertToNullableIfRequired(PropertyInformation propertyInfo, ITypeSymbol typeSymbol)
+    {
+        (bool isGeneratable, string genericTypeParam) = GetPropertyTypeName(typeSymbol);
+        if (typeSymbol.IsValueType && typeSymbol.SpecialType != SpecialType.System_Nullable_T && typeSymbol.NullableAnnotation != NullableAnnotation.Annotated)
+        {
+            propertyInfo.IsConvertedToNullableType = true;
+            genericTypeParam = $"System.Nullable<{genericTypeParam}>";
+        }
+        if (!typeSymbol.IsValueType && typeSymbol.SpecialType != SpecialType.System_Nullable_T)
+        {
+            genericTypeParam = $"{genericTypeParam}?";
         }
 
-        private void BuildNamespace(BuilderState state, Action<BuilderState>? addBody = null)
+        if (isGeneratable)
+            propertyInfo.Builder = new SimpleGeneratableBuilder(propertyInfo.Property);
+        else
+            propertyInfo.Builder = new SimpleNonGeneratableBuilder(propertyInfo.Property, propertyInfo.IsConvertedToNullableType);
+
+        return genericTypeParam;
+    }
+
+    private (bool IsGeneratedType, string TypeName) GetPropertyTypeName(ITypeSymbol propertyTypeSymbol)
+    {
+        if (GeneratedTypeFilter.IsGeneratableType(propertyTypeSymbol))
         {
-            state.AppendLine($"#nullable enable");
-            state.AppendLine($"namespace {NameBuilder.GetNamespace(state.TypeInfo.TypeSymbol)}");
-            state.AppendLine("{");
-            addBody?.Invoke(state.IncrementIdentation());
-            state.AppendLine("}");
-            state.AppendLine($"#nullable disable");
+            return (true, NameBuilder.GetFullTypeName(propertyTypeSymbol));
         }
+        return (false, propertyTypeSymbol.ToDisplayString(GeneratedTypeFilter.SymbolFormat));
+    }
 
-        private void BuildClassDeclaration(BuilderState state, Action<BuilderState>? addBody = null)
+    private void BuildAttributes(BuilderState state, IEnumerable<AttributeData> attributes)
+    {
+        foreach (var attribute in attributes)
+            if (attribute.AttributeClass?.ToDisplayString() != "System.Runtime.CompilerServices.NullableContextAttribute"
+                && attribute.AttributeClass?.ToDisplayString() != "System.Runtime.CompilerServices.NullableAttribute"
+                && attribute.AttributeClass?.ToDisplayString() != "LaDeak.JsonMergePatch.Abstractions.PatchableAttribute")
+                BuildAttribute(state, attribute);
+    }
+
+    private void BuildAttribute(BuilderState state, AttributeData attribute) => state.AppendLine($"[{attribute}]");
+
+    private void BuildAllProperties(BuilderState state)
+    {
+        for (int i = 0; i < state.TypeInfo.Properties.Count; i++)
         {
-            BuildAttributes(state, state.TypeInfo.TypeSymbol.GetAttributes());
-            state.AppendLine($"public class {state.TypeInfo.Name} : LaDeak.JsonMergePatch.Abstractions.Patch<{state.TypeInfo.SourceTypeName}>");
-            state.AppendLine("{");
-            addBody?.Invoke(state.IncrementIdentation());
-            state.AppendLine("}");
-        }
-
-        private void BuildConstructor(BuilderState state, Action<BuilderState>? addBody = null)
-        {
-            state.AppendLine($"public {state.TypeInfo.Name}()");
-            state.AppendLine("{");
-            var innerState = state.IncrementIdentation();
-            innerState.AppendLine($"Properties = new bool[{state.TypeInfo.Properties.Count}];");
-            addBody?.Invoke(innerState);
-            state.AppendLine("}");
-        }
-
-        private void BuildPropery(BuilderState state, PropertyInformation propertyInfo, int propertyId)
-        {
-            state.ToProcessTypeSymbols.Add(propertyInfo.Property.Type);
-            string fieldName = Casing.PrefixUnderscoreCamelCase(propertyInfo.Property.Name);
-            string propertyTypeName = GetPropertyTypeName(propertyInfo);
-            state.AppendLine($"private {propertyTypeName} {fieldName};");
-            BuildAttributes(state, propertyInfo.Property.GetAttributes());
-            state.AppendLine($"public {propertyTypeName} {propertyInfo.Property.Name}");
-            state.AppendLine("{");
-            var getterSetter = state.IncrementIdentation();
-            getterSetter.AppendLine($"get {{ return {fieldName}; }}");
-            getterSetter.AppendLine("set");
-            getterSetter.AppendLine("{");
-            var setterBody = getterSetter.IncrementIdentation();
-            setterBody.AppendLine($"Properties[{propertyId}] = true;");
-            setterBody.AppendLine($"{fieldName} = value;");
-            getterSetter.AppendLine("}");
-            state.AppendLine("}");
-        }
-
-        private string GetPropertyTypeName(PropertyInformation propertyInfo)
-        {
-            var propertyTypeSymbol = propertyInfo.Property.Type;
-            if (propertyTypeSymbol is INamedTypeSymbol namedType && namedType.IsGenericType)
-                return CreateGenericTypeWithParameters(propertyInfo);
-
-            return ConvertToNullableIfRequired(propertyInfo, propertyTypeSymbol);
-        }
-
-        private string CreateGenericTypeWithParameters(PropertyInformation propertyInfo)
-        {
-            if (propertyInfo?.Property?.Type is not INamedTypeSymbol namedType || !namedType.IsGenericType)
-                throw new InvalidOperationException("Parameter is not generic type parameter.");
-
-            propertyInfo.Builder = new SimpleNonGeneratableBuilder(propertyInfo.Property, false);
-            var firstUnderlyingType = GetPropertyTypeName(namedType.TypeArguments.First()).TypeName;
-            var withoutUnderlyingType = namedType.ToDisplayString(new SymbolDisplayFormat(SymbolDisplayGlobalNamespaceStyle.Omitted, SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces, SymbolDisplayGenericsOptions.None, SymbolDisplayMemberOptions.None, SymbolDisplayDelegateStyle.NameOnly, SymbolDisplayExtensionMethodStyle.Default, SymbolDisplayParameterOptions.IncludeType, SymbolDisplayPropertyStyle.NameOnly, SymbolDisplayLocalOptions.IncludeType, SymbolDisplayKindOptions.None, SymbolDisplayMiscellaneousOptions.ExpandNullable));
-
-            var genericResult = $"{withoutUnderlyingType}<{firstUnderlyingType}";
-            foreach (var underlyingType in namedType.TypeArguments.Skip(1).OfType<INamedTypeSymbol>())
-            {
-                string genericTypeParam = ConvertToNullableIfRequired(propertyInfo, underlyingType);
-                genericResult += $", {genericTypeParam}";
-            }
-            genericResult += ">";
-            if (namedType.SpecialType != SpecialType.System_Nullable_T && namedType.NullableAnnotation != NullableAnnotation.Annotated)
-            {
-                genericResult += "?";
-            }
-            if (namedType.Name.Contains("Dictionary") && namedType.ContainingNamespace.ToDisplayString() == "System.Collections.Generic")
-                propertyInfo.Builder = new NonGeneratableDictionaryPatchBuilder(namedType, propertyInfo.Property, propertyInfo.IsConvertedToNullableType);
-
-            if (namedType.Name.Contains("List")
-                && namedType.ContainingNamespace.ToDisplayString() == "System.Collections.Generic"
-                && !IsInitOnlyProperty(propertyInfo.Property)
-                && GeneratedTypeFilter.IsGeneratableType(namedType.TypeArguments.First()))
-                propertyInfo.Builder = new GeneratableListBuilder(namedType, propertyInfo.Property);
-
-            return genericResult;
-        }
-
-        private string ConvertToNullableIfRequired(PropertyInformation propertyInfo, ITypeSymbol typeSymbol)
-        {
-            (bool isGeneratable, string genericTypeParam) = GetPropertyTypeName(typeSymbol);
-            if (typeSymbol.IsValueType && typeSymbol.SpecialType != SpecialType.System_Nullable_T && typeSymbol.NullableAnnotation != NullableAnnotation.Annotated)
-            {
-                propertyInfo.IsConvertedToNullableType = true;
-                genericTypeParam = $"System.Nullable<{genericTypeParam}>";
-            }
-            if (!typeSymbol.IsValueType && typeSymbol.SpecialType != SpecialType.System_Nullable_T)
-            {
-                genericTypeParam = $"{genericTypeParam}?";
-            }
-
-            if (isGeneratable)
-                propertyInfo.Builder = new SimpleGeneratableBuilder(propertyInfo.Property);
-            else
-                propertyInfo.Builder = new SimpleNonGeneratableBuilder(propertyInfo.Property, propertyInfo.IsConvertedToNullableType);
-
-            return genericTypeParam;
-        }
-
-        private (bool IsGeneratedType, string TypeName) GetPropertyTypeName(ITypeSymbol propertyTypeSymbol)
-        {
-            if (GeneratedTypeFilter.IsGeneratableType(propertyTypeSymbol))
-            {
-                return (true, NameBuilder.GetFullTypeName(propertyTypeSymbol));
-            }
-            return (false, propertyTypeSymbol.ToDisplayString(GeneratedTypeFilter.SymbolFormat));
-        }
-
-        private void BuildAttributes(BuilderState state, IEnumerable<AttributeData> attributes)
-        {
-            foreach (var attribute in attributes)
-                if (attribute.AttributeClass?.ToDisplayString() != "System.Runtime.CompilerServices.NullableContextAttribute"
-                    && attribute.AttributeClass?.ToDisplayString() != "System.Runtime.CompilerServices.NullableAttribute"
-                    && attribute.AttributeClass?.ToDisplayString() != "LaDeak.JsonMergePatch.Abstractions.PatchableAttribute")
-                    BuildAttribute(state, attribute);
-        }
-
-        private void BuildAttribute(BuilderState state, AttributeData attribute) => state.AppendLine($"[{attribute}]");
-
-        private void BuildAllProperties(BuilderState state)
-        {
-            for (int i = 0; i < state.TypeInfo.Properties.Count; i++)
-            {
-                BuildPropery(state, state.TypeInfo.Properties[i], i);
-                state.AppendLine();
-            }
-        }
-
-        private void BuildClassBody(BuilderState state)
-        {
-            BuildConstructor(state);
+            BuildPropery(state, state.TypeInfo.Properties[i], i);
             state.AppendLine();
-            BuildAllProperties(state);
-            BuildApplyPath(state);
         }
+    }
 
-        private void BuildApplyPath(BuilderState state)
-        {
-            state.AppendLine($"public override {state.TypeInfo.SourceTypeName} ApplyPatch([System.Diagnostics.CodeAnalysis.AllowNull] {state.TypeInfo.SourceTypeName} input)");
-            state.AppendLine("{");
-            var bodyState = state.IncrementIdentation();
-            CallConstructIfEmpty(bodyState, "input ??=", leaveOpen: false);
-            SetInitOnlyProperties(bodyState);
-            SetReadWriteProperties(bodyState);
-            BuildApplyPatchEnumerations(bodyState);
-            bodyState.AppendLine("return input;");
-            state.AppendLine("}");
-        }
+    private void BuildClassBody(BuilderState state)
+    {
+        BuildConstructor(state);
+        state.AppendLine();
+        BuildAllProperties(state);
+        BuildApplyPath(state);
+    }
 
-        private void SetInitOnlyProperties(BuilderState state)
-        {
-            if (!state.TypeInfo.Properties.Any(x => IsInitOnlyProperty(x.Property)))
-                return;
-            CallConstructIfEmpty(state, "var tmp =", leaveOpen: true);
-            state.AppendLine("{");
-            var initializerState = state.IncrementIdentation();
-            for (int i = 0; i < state.TypeInfo.Properties.Count; i++)
-            {
-                var currentProperty = state.TypeInfo.Properties[i];
-                if (IsInitOnlyProperty(currentProperty.Property))
-                {
-                    currentProperty.Builder?.BuildInitOnly(state, i);
-                }
-                else
-                {
-                    // Copy old property values onto the new object
-                    initializerState.AppendLine($"{currentProperty.Property.Name} = input.{currentProperty.Property.Name},");
-                }
-            }
-            state.AppendLine("};");
-            state.AppendLine("input = tmp;");
-        }
+    private void BuildApplyPath(BuilderState state)
+    {
+        state.AppendLine($"public override {state.TypeInfo.SourceTypeName} ApplyPatch([System.Diagnostics.CodeAnalysis.AllowNull] {state.TypeInfo.SourceTypeName} input)");
+        state.AppendLine("{");
+        var bodyState = state.IncrementIdentation();
+        CallConstructIfEmpty(bodyState, "input ??=", leaveOpen: false);
+        SetInitOnlyProperties(bodyState);
+        SetReadWriteProperties(bodyState);
+        BuildApplyPatchEnumerations(bodyState);
+        bodyState.AppendLine("return input;");
+        state.AppendLine("}");
+    }
 
-        private void SetReadWriteProperties(BuilderState state)
-        {
-            for (int i = 0; i < state.TypeInfo.Properties.Count; i++)
-            {
-                var currentProperty = state.TypeInfo.Properties[i];
-                if (!IsInitOnlyProperty(currentProperty.Property))
-                    currentProperty.Builder?.BuildInstantiation(state, i);
-            }
-        }
-
-        private static void BuildApplyPatchEnumerations(BuilderState state)
-        {
-            for (int i = 0; i < state.TypeInfo.Properties.Count; i++)
-            {
-                var currentProperty = state.TypeInfo.Properties[i];
-                currentProperty.Builder?.BuildPatch(state);
-            }
-        }
-
-        private bool IsInitOnlyProperty(IPropertySymbol propertySymbol)
-        {
-            return propertySymbol.SetMethod?.OriginalDefinition.IsInitOnly ?? false;
-        }
-
-        private bool HasDefaultConstructor(ITypeSymbol typeSymbol)
-        {
-            return typeSymbol.GetMembers().OfType<IMethodSymbol>().Where(x => x.MethodKind == MethodKind.Constructor).AnyOrNull(x => x.Parameters.IsEmpty);
-        }
-
-        private void CallConstructIfEmpty(BuilderState state, string toInitialize, bool leaveOpen)
-        {
-            IEnumerable<string> parameters = Enumerable.Empty<string>();
-            if (!HasDefaultConstructor(state.TypeInfo.TypeSymbol))
-            {
-                var typeSymbol = state.TypeInfo.TypeSymbol;
-                var ctor = typeSymbol.GetMembers().OfType<IMethodSymbol>().Where(x => x.MethodKind == MethodKind.Constructor).OrderByDescending(x => x.Parameters.Length).First();
-                var properties = state.TypeInfo.Properties.Select(x => x.Property).ToList();
-                parameters = Enumerable.Repeat("default", ctor.Parameters.Length);
-            }
-            var ending = leaveOpen ? "" : ";";
-            state.AppendLine($"{toInitialize} new {state.TypeInfo.SourceTypeName}({string.Join(", ", parameters)}){ending}");
+    private void SetInitOnlyProperties(BuilderState state)
+    {
+        if (!state.TypeInfo.Properties.Any(x => IsInitOnlyProperty(x.Property)))
             return;
+        CallConstructIfEmpty(state, "var tmp =", leaveOpen: true);
+        state.AppendLine("{");
+        var initializerState = state.IncrementIdentation();
+        for (int i = 0; i < state.TypeInfo.Properties.Count; i++)
+        {
+            var currentProperty = state.TypeInfo.Properties[i];
+            if (IsInitOnlyProperty(currentProperty.Property))
+            {
+                currentProperty.Builder?.BuildInitOnly(state, i);
+            }
+            else
+            {
+                // Copy old property values onto the new object
+                initializerState.AppendLine($"{currentProperty.Property.Name} = input.{currentProperty.Property.Name},");
+            }
         }
+        state.AppendLine("};");
+        state.AppendLine("input = tmp;");
+    }
+
+    private void SetReadWriteProperties(BuilderState state)
+    {
+        for (int i = 0; i < state.TypeInfo.Properties.Count; i++)
+        {
+            var currentProperty = state.TypeInfo.Properties[i];
+            if (!IsInitOnlyProperty(currentProperty.Property))
+                currentProperty.Builder?.BuildInstantiation(state, i);
+        }
+    }
+
+    private static void BuildApplyPatchEnumerations(BuilderState state)
+    {
+        for (int i = 0; i < state.TypeInfo.Properties.Count; i++)
+        {
+            var currentProperty = state.TypeInfo.Properties[i];
+            currentProperty.Builder?.BuildPatch(state);
+        }
+    }
+
+    private bool IsInitOnlyProperty(IPropertySymbol propertySymbol)
+    {
+        return propertySymbol.SetMethod?.OriginalDefinition.IsInitOnly ?? false;
+    }
+
+    private bool HasDefaultConstructor(ITypeSymbol typeSymbol)
+    {
+        return typeSymbol.GetMembers().OfType<IMethodSymbol>().Where(x => x.MethodKind == MethodKind.Constructor).AnyOrNull(x => x.Parameters.IsEmpty);
+    }
+
+    private void CallConstructIfEmpty(BuilderState state, string toInitialize, bool leaveOpen)
+    {
+        IEnumerable<string> parameters = Enumerable.Empty<string>();
+        if (!HasDefaultConstructor(state.TypeInfo.TypeSymbol))
+        {
+            var typeSymbol = state.TypeInfo.TypeSymbol;
+            var ctor = typeSymbol.GetMembers().OfType<IMethodSymbol>().Where(x => x.MethodKind == MethodKind.Constructor).OrderByDescending(x => x.Parameters.Length).First();
+            var properties = state.TypeInfo.Properties.Select(x => x.Property).ToList();
+            parameters = Enumerable.Repeat("default", ctor.Parameters.Length);
+        }
+        var ending = leaveOpen ? "" : ";";
+        state.AppendLine($"{toInitialize} new {state.TypeInfo.SourceTypeName}({string.Join(", ", parameters)}){ending}");
+        return;
     }
 }

--- a/src/JsonMergePatch.SourceGenerator/TypeInformation.cs
+++ b/src/JsonMergePatch.SourceGenerator/TypeInformation.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders;
 using Microsoft.CodeAnalysis;
 
 namespace LaDeak.JsonMergePatch.SourceGenerator
@@ -15,8 +16,10 @@ namespace LaDeak.JsonMergePatch.SourceGenerator
     {
         public IPropertySymbol? Property { get; set; }
         public bool IsConvertedToNullableType { get; set; }
-        public bool IsGenericDictionary { get; set; }
-        public bool IsGenericList { get; set; }
-        public ITypeSymbol? FirstGenericType { get; set; }
+        //public bool IsGenericDictionary { get; set; }
+        //public bool IsGenericList { get; set; }
+        //public ITypeSymbol? FirstGenericType { get; set; }
+
+        public ApplyPatchBuilder? Builder { get; set; }
     }
 }

--- a/src/JsonMergePatch.SourceGenerator/TypeInformation.cs
+++ b/src/JsonMergePatch.SourceGenerator/TypeInformation.cs
@@ -2,24 +2,19 @@
 using LaDeak.JsonMergePatch.SourceGenerator.ApplyPatchBuilders;
 using Microsoft.CodeAnalysis;
 
-namespace LaDeak.JsonMergePatch.SourceGenerator
+namespace LaDeak.JsonMergePatch.SourceGenerator;
+
+public class TypeInformation
 {
-    public class TypeInformation
-    {
-        public string? Name { get; set; }
-        public string? SourceTypeName { get; set; }
-        public List<PropertyInformation> Properties { get; } = new List<PropertyInformation>();
-        public ITypeSymbol? TypeSymbol { get; set; }
-    }
+    public string? Name { get; set; }
+    public string? SourceTypeName { get; set; }
+    public List<PropertyInformation> Properties { get; } = new List<PropertyInformation>();
+    public ITypeSymbol? TypeSymbol { get; set; }
+}
 
-    public class PropertyInformation
-    {
-        public IPropertySymbol? Property { get; set; }
-        public bool IsConvertedToNullableType { get; set; }
-        //public bool IsGenericDictionary { get; set; }
-        //public bool IsGenericList { get; set; }
-        //public ITypeSymbol? FirstGenericType { get; set; }
-
-        public ApplyPatchBuilder? Builder { get; set; }
-    }
+public class PropertyInformation
+{
+    public IPropertySymbol? Property { get; set; }
+    public bool IsConvertedToNullableType { get; set; }
+    public ApplyPatchBuilder? Builder { get; set; }
 }


### PR DESCRIPTION
Refactoring specific builders (Dictionary, List, etc.) into specialized Builders.
Refactoring Tag type to use Value for the property name, this looks more reasonable for a sample.
Adding missing code comments.
Using file scoped namespaces.